### PR TITLE
Heavy code modification to reflect changes in bson package

### DIFF
--- a/snap-web.cabal
+++ b/snap-web.cabal
@@ -28,28 +28,28 @@ Executable snap-web
     MonadCatchIO-transformers    >= 0.3   && < 0.4,
     aeson                        >= 0.6   && < 0.7,
     base                         >= 4     && < 5,
-    bson                         >= 0.1.7 && < 0.2,
-    bytestring                   >= 0.9.1 && < 0.10,
-    clientsession                >= 0.7.4 && < 0.8,
+    bson                         >= 0.1.7 && < 0.2.2,
+    bytestring                   >= 0.9.1 && < 0.12,
+    clientsession                >= 0.7.4 && < 0.9,
     compact-string-fix           >= 0.3   && < 0.4,
     configurator                 >= 0.2   && < 0.3,
-    containers                   >= 0.4   && < 0.5,
-    data-lens                    >= 2.0.1 && < 2.1,
+    containers                   >= 0.4   && < 0.6,
+    data-lens                    >= 2.0.1 ,
     data-lens-template           >= 2.1   && < 2.2,
     digestive-functors           == 0.5.*,
     digestive-functors-heist     >= 0.5   && < 0.6,
     digestive-functors-snap      >= 0.5   && < 0.6,
     heist                        >= 0.8   && < 0.9,
-    mongoDB                      >= 1.2   && < 2.0,
+    mongoDB                      >= 1.3   && < 2.0,
     mtl                          >= 2     && < 3,
     old-locale                   >= 1.0   && < 1.1,
-    pandoc                       >= 1.9   && < 1.9.4,
+    pandoc                       >= 1.9,
     resource-pool                >= 0.2   && < 0.3,
-    snap                         == 0.9.*,
-    snap-core                    == 0.9.*,
-    snap-loader-dynamic          == 0.9.*,
-    snap-loader-static           == 0.9.*,
-    snap-server                  == 0.9.*,
+    snap                         >= 0.9,
+    snap-core                    >= 0.9,
+    snap-loader-dynamic          >= 0.9,
+    snap-loader-static           >= 0.9,
+    snap-server                  >= 0.9,
     snaplet-i18n                 == 0.0.3,
     snaplet-mongodb-minimalistic >= 0.0.6 && < 0.0.7,
     text                         >= 0.11  && < 0.12,
@@ -57,7 +57,7 @@ Executable snap-web
     unordered-containers         >= 0.2   && < 0.3,
     utf8-string                  >= 0.3.7 && < 0.4,
     xss-sanitize                 >= 0.3   && < 0.4,
-    xmlhtml                      == 0.2.0
+    xmlhtml                      >= 0.2.0
 
 
   if flag(development)
@@ -95,5 +95,5 @@ Executable migrate
   Ghc-options:    -Wall -isrc
   Build-depends:
     base                 >= 4    && < 5,
-    bson                         >= 0.1.7 && < 0.2,
-    pwstore-fast == 2.2
+    bson                         >= 0.1.7 && < 0.2.2,
+    pwstore-fast >= 2.2

--- a/src/Models/Reply.hs
+++ b/src/Models/Reply.hs
@@ -36,7 +36,7 @@ data Reply = Reply
     } deriving (Show, Eq)
 
 replyCollection :: Collection
-replyCollection = u "replies"
+replyCollection = "replies"
 
 -----------------------------------------------------------------------
 

--- a/src/Models/Tag.hs
+++ b/src/Models/Tag.hs
@@ -32,7 +32,7 @@ emptyTag = Tag Nothing "" Nothing
 -- | Schema name
 --
 tagCollection :: Collection
-tagCollection = u "tags"
+tagCollection = "tags"
 
 
 --------------------------------------------------------------------------------

--- a/src/Models/Topic.hs
+++ b/src/Models/Topic.hs
@@ -35,7 +35,7 @@ data Topic = Topic
     } deriving (Show, Eq)
 
 topicCollection :: Collection
-topicCollection = u "topics"
+topicCollection = "topics"
 
 getTopicId :: Topic -> T.Text
 getTopicId = objectIdToText . _topicId

--- a/src/Models/User.hs
+++ b/src/Models/User.hs
@@ -64,7 +64,7 @@ data User = User
 -- | This is where User extra information saved, making diff wih AuthUser.
 --
 authUserCollection :: DB.Collection
-authUserCollection = u "users"
+authUserCollection = "users"
 
 ------------------------------------------------------------------------------
 

--- a/src/Snap/Snaplet/Auth/Backends/MongoDB.hs
+++ b/src/Snap/Snaplet/Auth/Backends/MongoDB.hs
@@ -72,7 +72,8 @@ initMongoAuth sess db sk = makeSnaplet "mongodb-auth" desc Nothing $ do
     key <- liftIO $ getKey (fromMaybe (asSiteKey authSettings) sk)
     let
       lens' = getL snapletValue db
-      manager = MongoBackend (M.u authTable) (SM.mongoDatabase lens')
+      --manager = MongoBackend (M.u authTable) (SM.mongoDatabase lens')
+      manager = MongoBackend authTable (SM.mongoDatabase lens')
                 (SM.mongoPool lens')
     rng <- liftIO mkRNG
     return AuthManager

--- a/src/Snap/Snaplet/Environments.hs
+++ b/src/Snap/Snaplet/Environments.hs
@@ -14,7 +14,6 @@ import           Data.Configurator
 import           Data.Configurator.Types
 import           Data.Maybe              (fromMaybe)
 import qualified Data.Text               as T
-import qualified Data.UString            as U
 import           Snap.Snaplet
 
 
@@ -37,10 +36,3 @@ lookupConfigDefault :: (MonadIO (m b v), MonadSnaplet m, Configured a)
                           -> m b v a
 lookupConfigDefault name def = liftM (fromMaybe def) (lookupConfig name)
 
------------------------------------------------------------
-
--- | This is required for `mongoDBInit` from Snaplet.MongoDB
---
-instance Configured U.UString where
-  convert (String t) = Just $ U.u $ T.unpack t
-  convert _ = Nothing


### PR DESCRIPTION
Since bson-2.0.0, there  is no `Data.UString` module. The most important change is from  

```
type Label = UString
```

to 

```
type Label = Text
```

p.s. Version relaxation of several packages.
